### PR TITLE
fixed empty property for first seed object

### DIFF
--- a/script/shows.js
+++ b/script/shows.js
@@ -1,7 +1,7 @@
 
 const shows = [
   {
-    spotify_id: 'empty',
+    spotify_id: '1',
     name: 'test-show-1',
     description: 'test-description',
     publisher: 'test-publisher',


### PR DESCRIPTION
- first record now has '1' for spotify_id, instead of 'empty'